### PR TITLE
Change MQTT topics for Home Assistant 2023.8 update

### DIFF
--- a/ISP-RPi-mqtt-daemon.py
+++ b/ISP-RPi-mqtt-daemon.py
@@ -1381,7 +1381,7 @@ print_line('Announcing RPi Monitoring device to MQTT broker for auto-discovery .
 #  table of key items to publish:
 detectorValues = OrderedDict([
     (K_LD_MONITOR, dict(
-        title="RPi Monitor {}".format(rpi_hostname),
+        title="Monitor",
         topic_category="sensor",
         device_class="timestamp",
         device_ident="RPi-{}".format(rpi_fqdn),
@@ -1391,7 +1391,7 @@ detectorValues = OrderedDict([
         json_value="timestamp",
     )),
     (K_LD_SYS_TEMP, dict(
-        title="RPi Temp {}".format(rpi_hostname),
+        title="Temperature",
         topic_category="sensor",
         device_class="temperature",
         no_title_prefix="yes",
@@ -1400,7 +1400,7 @@ detectorValues = OrderedDict([
         json_value="temperature_c",
     )),
     (K_LD_FS_USED, dict(
-        title="RPi Disk Used {}".format(rpi_hostname),
+        title="Disk Used",
         topic_category="sensor",
         no_title_prefix="yes",
         unit="%",
@@ -1408,7 +1408,7 @@ detectorValues = OrderedDict([
         json_value="fs_used_prcnt",
     )),
     (K_LD_CPU_USE, dict(
-        title="RPi CPU Use {}".format(rpi_hostname),
+        title="CPU Use",
         topic_category="sensor",
         no_title_prefix="yes",
         unit="%",
@@ -1416,7 +1416,7 @@ detectorValues = OrderedDict([
         json_value=K_LD_CPU_USE_JSON,
     )),
     (K_LD_MEM_USED, dict(
-        title="RPi Mem Used {}".format(rpi_hostname),
+        title="Memory Used",
         topic_category="sensor",
         no_title_prefix="yes",
         json_value="mem_used_prcnt",
@@ -1436,7 +1436,7 @@ for [command, _] in commands.items():
         iconName = 'mdi:cog-counterclockwise'
     detectorValues.update({
         command: dict(
-            title='RPi {} {} Command'.format(command, rpi_hostname),
+            title=command,
             topic_category='button',
             no_title_prefix='yes',
             icon=iconName,

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ password = {your mqtt password if your setup requires one}
 
 Now that your config.ini is setup let's test!
 
-**NOTE:** *If you wish to support remote commanding of your RPi then you can find additional configuration steps in [Setting up RPi Control from Home Assistant](./RMTCTRL.md)  However, to simplifly your effort, please complete the following steps to ensure all is running as desired before you attempt to set up remote control.*
+**NOTE:** *If you wish to support remote commanding of your RPi then you can find additional configuration steps in [Setting up RPi Control from Home Assistant](./RMTECTRL.md)  However, to simplifly your effort, please complete the following steps to ensure all is running as desired before you attempt to set up remote control.*
 
 ## Execution
 


### PR DESCRIPTION
As described in a recent blog post ([PSA: MQTT Name changes in 2023.8](https://community.home-assistant.io/t/psa-mqtt-name-changes-in-2023-8/598099)), the way Home Assistant handles MQTT names will change.

It is no longer necessary to include the device name in the entity.

I removed the device name from the entities name. This makes the device page cleaner, as shown here:
![image](https://github.com/ironsheep/RPi-Reporter-MQTT2HA-Daemon/assets/21108660/420abd18-6ed1-4d91-bd3b-1d3639763876)

And the device name is added automatically to the entity:
![image](https://github.com/ironsheep/RPi-Reporter-MQTT2HA-Daemon/assets/21108660/1423462e-6621-4d94-9d2f-b6d425593be3)

