### PR TITLE
Always update sensor_name after resolving hostname

### DIFF
--- a/ISP-RPi-mqtt-daemon.py
+++ b/ISP-RPi-mqtt-daemon.py
@@ -1202,8 +1202,8 @@ def getNumberOfAvailableUpdates():
 
 # get our hostnames so we can setup MQTT
 getHostnames()
-if(sensor_name == default_sensor_name):
-    sensor_name = 'rpi-{}'.format(rpi_hostname)
+sensor_name = 'rpi-{}'.format(rpi_hostname)
+
 # get model so we can use it too in MQTT
 getDeviceModel()
 getDeviceCpuInfo()


### PR DESCRIPTION
My pi's weren't registering correctly and I was getting a lot of MQTT traffic with rpi_{hostname}.
This is because the "default_sensor_name" is not the same as the MQTT.sensor_name config, and yet the default sensor name is being used to validate whether to set the hostname.

Until the logic for reconciling the MQTT config and the default sensor name is more meaningful, it's better to just ALWAYS set the sensor name correctly.