### PR TITLE
Add state_class=measurement to sensors

### DIFF
--- a/ISP-RPi-mqtt-daemon.py
+++ b/ISP-RPi-mqtt-daemon.py
@@ -1439,6 +1439,7 @@ detectorValues = OrderedDict([
         title="Temperature",
         topic_category="sensor",
         device_class="temperature",
+        state_class="measurement",
         no_title_prefix="yes",
         unit="°C",
         icon='mdi:thermometer',
@@ -1447,6 +1448,7 @@ detectorValues = OrderedDict([
     (K_LD_FS_USED, dict(
         title="Disk Used",
         topic_category="sensor",
+        state_class="measurement",
         no_title_prefix="yes",
         unit="%",
         icon='mdi:sd',
@@ -1455,6 +1457,7 @@ detectorValues = OrderedDict([
     (K_LD_CPU_USE, dict(
         title="CPU Use",
         topic_category="sensor",
+        state_class="measurement",
         no_title_prefix="yes",
         unit="%",
         icon=cpu_use_icon,
@@ -1463,6 +1466,7 @@ detectorValues = OrderedDict([
     (K_LD_MEM_USED, dict(
         title="Memory Used",
         topic_category="sensor",
+        state_class="measurement",
         no_title_prefix="yes",
         json_value="mem_used_prcnt",
         unit="%",


### PR DESCRIPTION
Based on HA's [documentation](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics):
> Home Assistant has support for storing sensors as long-term statistics if the entity has the right properties. To opt-in for statistics, the sensor must have `state_class` set to one of the valid state classes: `measurement`, `total` or `total_increasing`.

I think it makes sense for the numeric sensors to be included in long-term statistics, and thus it would be good to include this field in the discovery message.